### PR TITLE
Add getDockerHost code snippet

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 *.json text eol=lf
 *.conf text eol=lf
 **/bin/* text eol=lf
+**/snippets/* text eol=lf

--- a/code/snippets/README.md
+++ b/code/snippets/README.md
@@ -1,0 +1,25 @@
+# Code Snippets
+
+## getDockerHost
+
+Gets the Docker host address depending on the host system.  Refer to the documentation in the script for further details; [getDockerHost](./getDockerHost).
+
+To use this function in your script add the following two lines:
+```
+. /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))" 
+export DOCKERHOST=$(getDockerHost)
+```
+
+This code includes a workaround for known limitations of process substitution in bash 3.2 which can be found on many Macs; [Why source command doesn't work with process substitution in bash 3.2?](https://stackoverflow.com/a/32596626).  This workaround also works on newer versions of bash.
+
+Example of the version of bash that requires the workaround;
+```
+GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin21)
+Copyright (C) 2007 Free Software Foundation, Inc.
+```
+
+For completeness, on newer versions of bash the process substitution could be written as:
+```
+. <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost)
+```
+However you then loose the backward compatibility with the older versions of bash.

--- a/code/snippets/getDockerHost
+++ b/code/snippets/getDockerHost
@@ -1,0 +1,31 @@
+# ====================================================================
+# Get the Docker host address depending on the host system.
+#
+# Networking changes introduced in Docker 4.1.x and forward on 
+# Windows and MAC stop the direct use of the internal docker host IP 
+# returned by the `docker run --rm --net=host eclipse/che-ip` process. 
+# On Windows and MAC `host.docker.internal` needs to be used for 
+# internal connections between containers on separate docker networks.
+#
+# `host.docker.internal` has been available on Windows and Mac since 
+# Docker Engine version 18.03 (March 2018). 
+#
+# Support for `host.docker.internal` on Linux was introduced in 
+# version 20.10.0 (2020-12-08), but it does not run out of the 
+# box yet (as of Docker Engine 20.10.11 (2021-11-17)). 
+# You need to add `--add-host=host.docker.internal:host-gateway` 
+# to the `docker run` command in order for it to work.
+# --------------------------------------------------------------------
+function getDockerHost() {
+  (
+    local dockerHostAddress
+    unset dockerHostAddress
+    if [[ $(uname) == "Linux" ]] ; then
+      dockerHostAddress=$(docker run --rm --net=host eclipse/che-ip)
+    else
+      dockerHostAddress=host.docker.internal
+    fi
+    echo ${DOCKERHOST:-${APPLICATION_URL:-${dockerHostAddress}}}
+  )
+}
+# ====================================================================


### PR DESCRIPTION
For use with our various manage scripts.  To centralize the process of getting the Docker host address, rather than duplicating the exact same code in numerous locations.